### PR TITLE
Backward compatibility test

### DIFF
--- a/agreement/events_test.go
+++ b/agreement/events_test.go
@@ -1,0 +1,88 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package agreement
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/algorand/go-algorand/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSerializableErrorBackwardCompatible ensures Err field of type serializableError can be
+// properly decoded from ConsensusVersionView.
+// This test is only needed for agreement state serialization switch from reflection to msgp.
+func TestSerializableErrorBackwardCompatibility(t *testing.T) {
+
+	encodedEmpty, err := base64.StdEncoding.DecodeString("gqNFcnLAp1ZlcnNpb26jdjEw")
+	require.NoError(t, err)
+
+	encoded, err := base64.StdEncoding.DecodeString("gqNFcnKndGVzdGVycqdWZXJzaW9uo3YxMA==")
+	require.NoError(t, err)
+
+	// run on master f57a276 to get the encoded data for above
+	// cv := ConsensusVersionView{
+	// 	Err:     nil,
+	// 	Version: protocol.ConsensusV10,
+	// }
+
+	// result := protocol.EncodeReflect(&cv)
+	// fmt.Println(base64.StdEncoding.EncodeToString(result))
+
+	// se := serializableErrorUnderlying("testerr")
+	// cv = ConsensusVersionView{
+	// 	Err:     &se,
+	// 	Version: protocol.ConsensusV10,
+	// }
+
+	// result = protocol.EncodeReflect(&cv)
+	// fmt.Println(base64.StdEncoding.EncodeToString(result))
+
+	cvEmpty := ConsensusVersionView{
+		Err:     nil,
+		Version: protocol.ConsensusV10,
+	}
+
+	se := serializableError("testerr")
+	cv := ConsensusVersionView{
+		Err:     &se,
+		Version: protocol.ConsensusV10,
+	}
+
+	cv1 := ConsensusVersionView{}
+	err = protocol.Decode(encodedEmpty, &cv1)
+	require.NoError(t, err)
+
+	cv2 := ConsensusVersionView{}
+	err = protocol.DecodeReflect(encodedEmpty, &cv2)
+	require.NoError(t, err)
+
+	require.Equal(t, cv1, cv2)
+	require.Equal(t, cvEmpty, cv2)
+
+	cv1 = ConsensusVersionView{}
+	err = protocol.Decode(encoded, &cv1)
+	require.NoError(t, err)
+
+	cv2 = ConsensusVersionView{}
+	err = protocol.DecodeReflect(encoded, &cv2)
+	require.NoError(t, err)
+
+	require.Equal(t, cv1, cv2)
+	require.Equal(t, cv, cv2)
+}

--- a/agreement/message_test.go
+++ b/agreement/message_test.go
@@ -84,6 +84,9 @@ func BenchmarkVoteDecoding(b *testing.B) {
 	}
 }
 
+// TestMessageBackwardCompatibility ensures MessageHandle field can be
+// properly decoded from message.
+// This test is only needed for agreement state serialization switch from reflection to msgp.
 func TestMessageBackwardCompatibility(t *testing.T) {
 	partitiontest.PartitionTest(t)
 

--- a/agreement/message_test.go
+++ b/agreement/message_test.go
@@ -17,6 +17,7 @@
 package agreement
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,7 +25,9 @@ import (
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/committee"
+	"github.com/algorand/go-algorand/network"
 	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/test/partitiontest"
 )
 
 var poolAddr = basics.Address{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
@@ -79,4 +82,40 @@ func BenchmarkVoteDecoding(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		decodeVote(msgBytes)
 	}
+}
+
+func TestMessageBackwardCompatibility(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	type messageMetadata struct {
+		raw network.IncomingMessage
+	}
+
+	encoded, err := base64.StdEncoding.DecodeString("iaZCdW5kbGWAr0NvbXBvdW5kTWVzc2FnZYKoUHJvcG9zYWyApFZvdGWArU1lc3NhZ2VIYW5kbGWAqFByb3Bvc2FsgKNUYWeiUFC1VW5hdXRoZW50aWNhdGVkQnVuZGxlgLdVbmF1dGhlbnRpY2F0ZWRQcm9wb3NhbICzVW5hdXRoZW50aWNhdGVkVm90ZYCkVm90ZYA=")
+	require.NoError(t, err)
+
+	// run on master f57a276 to get the encoded data for above
+	// msg := message{
+	// 	MessageHandle: &messageMetadata{raw: network.IncomingMessage{Tag: protocol.Tag("mytag"), Data: []byte("some data")}},
+	// 	Tag:           protocol.ProposalPayloadTag,
+	// }
+
+	// result := protocol.EncodeReflect(&msg)
+	// fmt.Println(base64.StdEncoding.EncodeToString(result))
+
+	m1 := message{
+		messageHandle: &messageMetadata{raw: network.IncomingMessage{Tag: protocol.Tag("mytag"), Data: []byte("some data")}},
+		Tag:           protocol.ProposalPayloadTag,
+	}
+
+	var m2 message
+	err = protocol.Decode(encoded, &m2)
+	require.NoError(t, err)
+
+	var m3 message
+	err = protocol.DecodeReflect(encoded, &m3)
+	require.NoError(t, err)
+
+	require.Equal(t, m2, m3)
+	require.Equal(t, m1, m2)
 }


### PR DESCRIPTION
The test checking the old messages can be deserialized. Currently fails b/c of the MessageHandler renaming.