### PR TITLE
Suggestion

### DIFF
--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -252,6 +252,8 @@ type IncomingMessage struct {
 	// is used to ensure fairness across peers in terms of processing
 	// messages.
 	processing chan struct{}
+
+	CallWhenDone func()
 }
 
 // Tag is a short string (2 bytes) marking a type of message

--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -585,7 +585,7 @@ func TestWebsocketNetworkCancel(t *testing.T) {
 	msgs[50].ctx = ctx
 
 	for _, peer := range peers {
-		peer.sendBufferHighPrio <- sendMessages{msgs}
+		peer.sendBufferHighPrio <- sendMessages{msgs: msgs}
 	}
 
 	select {

--- a/rpcs/blockService.go
+++ b/rpcs/blockService.go
@@ -303,6 +303,9 @@ func (bs *BlockService) handleCatchupReq(ctx context.Context, reqMsg network.Inc
 	var respTopics network.Topics
 
 	defer func() {
+		reqMsg.CallWhenDone = func() {
+			// decrement the counter here
+		}
 		target.Respond(ctx, reqMsg, respTopics)
 	}()
 


### PR DESCRIPTION
This is a suggestion to keep the memory accounting in `blockService.go` and use a callback to decrement the counter when the network layer writes the message. 